### PR TITLE
Fix TypeError

### DIFF
--- a/examples/cms-storyblok/components/avatar.js
+++ b/examples/cms-storyblok/components/avatar.js
@@ -2,7 +2,7 @@ export default function Avatar({ name, picture }) {
   return (
     <div className="flex items-center">
       <img
-        src={picture.filename}
+        src={picture}
         className="w-12 h-12 rounded-full mr-4 grayscale"
         alt={name}
       />


### PR DESCRIPTION
TypeError: Cannot read property "filename" of undefined

````
TypeError: Cannot read property 'filename' of undefined
    at Avatar (webpack-internal:///./components/avatar.js:21:18)
    at processChild (/Users/oliver.montes/Sites/devopensource/streaming/landings/cms-storyblok-app/node_modules/react-dom/cjs/react-dom-server.node.development.js:3043:14)
    at resolve (/Users/oliver.montes/Sites/devopensource/streaming/landings/cms-storyblok-app/node_modules/react-dom/cjs/react-dom-server.node.development.js:2960:5)
    at ReactDOMServerRenderer.render (/Users/oliver.montes/Sites/devopensource/streaming/landings/cms-storyblok-app/node_modules/react-dom/cjs/react-dom-server.node.development.js:3435:22)
    at ReactDOMServerRenderer.read (/Users/oliver.montes/Sites/devopensource/streaming/landings/cms-storyblok-app/node_modules/react-dom/cjs/react-dom-server.node.development.js:3373:29)
    at renderToString (/Users/oliver.montes/Sites/devopensource/streaming/landings/cms-storyblok-app/node_modules/react-dom/cjs/react-dom-server.node.development.js:3988:27)
    at Object.renderPage (/Users/oliver.montes/Sites/devopensource/streaming/landings/cms-storyblok-app/node_modules/next/dist/next-server/server/render.js:50:851)
    at Function.getInitialProps (webpack-internal:///./node_modules/next/dist/pages/_document.js:141:19)
    at loadGetInitialProps (/Users/oliver.montes/Sites/devopensource/streaming/landings/cms-storyblok-app/node_modules/next/dist/next-server/lib/utils.js:5:101)
    at renderToHTML (/Users/oliver.montes/Sites/devopensource/streaming/landings/cms-storyblok-app/node_modules/next/dist/next-server/server/render.js:50:1142)
`````
